### PR TITLE
Update action version for copy / paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Deploy static websites to Blossom/Nostr in a Github Actions Workflow, powered by
 3. **Add to workflow**:
    ```yaml
    - name: Deploy to Nostr/Blossom
-     uses: sandwichfarm/nsite-action@v1
+     uses: sandwichfarm/nsite-action@v0.2.2
      with:
        nbunksec: ${{ secrets.NBUNKSEC }}
        directory: './dist'  # Your built website directory


### PR DESCRIPTION
It may also be a good idea to somehow create `v0.1` and `v0.2` tags that stay up to date with the latest patches