### PR TITLE
fix action version input docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,9 +58,18 @@ jobs:
       - name: Verify Action Attempted Run
         shell: bash
         run: |
+          echo "Action step outcome: ${{ steps.test_run.outcome }}"
+          echo "Action step conclusion: ${{ steps.test_run.conclusion }}"
           echo "Action outputs from test_run step:"
           echo "  Status: ${{ steps.test_run.outputs.status }}"
           echo "  nsyte Version Used: ${{ steps.test_run.outputs.nsyte_version_used }}"
+
+          if [[ "${{ steps.test_run.outcome }}" != "failure" ]]; then
+            echo "::error::Expected the action step outcome to be 'failure' when nsyte exits non-zero, but got '${{ steps.test_run.outcome }}'."
+            exit 1
+          else
+            echo "Action step outcome correctly reported as 'failure'."
+          fi
           
           if [[ -z "${{ steps.test_run.outputs.nsyte_version_used }}" ]]; then
             echo "::error::Output 'nsyte_version_used' was NOT set."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,12 +48,12 @@ jobs:
             wss://nostr.example.com
             wss://relay.example.org
           servers: |
-            wss://blossom.example.com
+            https://blossom.example.com
           force: true
           verbose: true
           fallback: '/fallback.html'
           concurrency: 2
-        continue-on-error: true # Expect failure with dummy nbunksec/relays/servers
+        continue-on-error: true # Expect failure with dummy signing secret/relays/servers
 
       - name: Verify Action Attempted Run
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         # Test on common OSes. Add more if nsyte supports them and has releases.
         os: [ubuntu-latest, macos-latest, windows-latest]
         # Use 'latest' to test the version resolution logic
-        nsyte_version: ['latest']
+        version: ['latest']
 
     steps:
       - name: Checkout Repository
@@ -43,7 +43,7 @@ jobs:
         with:
           sec: ${{ env.DUMMY_SEC }}
           directory: './test-dist'
-          nsyte_version: ${{ matrix.nsyte_version }}
+          version: ${{ matrix.version }}
           relays: |
             wss://nostr.example.com
             wss://relay.example.org
@@ -77,9 +77,9 @@ jobs:
             echo "Status output correctly set to 'failure'."
           fi
 
-          # Check if the version used is the expected latest (v0.5.3) when input is 'latest'
-          if [[ "${{ inputs.nsyte_version }}" == "latest" && "${{ steps.test_run.outputs.nsyte_version_used }}" != "v0.5.3" ]]; then
-            echo "::warning::Latest version detected was ${{ steps.test_run.outputs.nsyte_version_used }}, expected v0.5.3. Check nsyte release tagging or the action's version resolution logic."
+          # Check if the version used resolves to the current latest stable release when input is 'latest'
+          if [[ "${{ matrix.version }}" == "latest" && "${{ steps.test_run.outputs.nsyte_version_used }}" != "v0.21.5" ]]; then
+            echo "::warning::Latest stable version detected was ${{ steps.test_run.outputs.nsyte_version_used }}, expected v0.21.5. Check nsyte release tagging or the action's version resolution logic."
             # Not failing the test for this warning, but it's important to note.
           fi
           echo "Verification passed: Outputs are populated, and status is 'failure' as expected with dummy inputs." 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,8 +78,8 @@ jobs:
           fi
 
           # Check if the version used resolves to the current latest stable release when input is 'latest'
-          if [[ "${{ matrix.version }}" == "latest" && "${{ steps.test_run.outputs.nsyte_version_used }}" != "v0.21.5" ]]; then
-            echo "::warning::Latest stable version detected was ${{ steps.test_run.outputs.nsyte_version_used }}, expected v0.21.5. Check nsyte release tagging or the action's version resolution logic."
+          if [[ "${{ matrix.version }}" == "latest" && "${{ steps.test_run.outputs.nsyte_version_used }}" != "v0.23.0" ]]; then
+            echo "::warning::Latest stable version detected was ${{ steps.test_run.outputs.nsyte_version_used }}, expected v0.23.0. Check nsyte release tagging or the action's version resolution logic."
             # Not failing the test for this warning, but it's important to note.
           fi
           echo "Verification passed: Outputs are populated, and status is 'failure' as expected with dummy inputs." 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,8 @@ jobs:
           mkdir test-dist
           echo "<html>Test index.html</html>" > test-dist/index.html
           echo "<html>Test fallback.html</html>" > test-dist/fallback.html 
-          echo "DUMMY_SEC=nbunksec1fakebunkersecretstringforactiontestingpurposesonly" >> $GITHUB_ENV
+          echo "DUMMY_NBUNKSEC=nbunksec1fakebunkersecretstringforactiontestingpurposesonly" >> $GITHUB_ENV
+          echo "DUMMY_SEC1=sec1fakeprivatekeystringforvalidationtestingonly" >> $GITHUB_ENV
 
       - name: Run nsite-action (Local Path)
         uses: ./ 
@@ -41,7 +42,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         with:
-          sec: ${{ env.DUMMY_SEC }}
+          nbunksec: ${{ env.DUMMY_NBUNKSEC }}
           directory: './test-dist'
           version: ${{ matrix.version }}
           relays: |
@@ -54,6 +55,17 @@ jobs:
           fallback: '/fallback.html'
           concurrency: 2
         continue-on-error: true # Expect failure with dummy signing secret/relays/servers
+
+      - name: Reject sec1 value in nbunksec input
+        uses: ./
+        id: reject_sec1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          nbunksec: ${{ env.DUMMY_SEC1 }}
+          directory: './test-dist'
+          version: ${{ matrix.version }}
+        continue-on-error: true
 
       - name: Verify Action Attempted Run
         shell: bash
@@ -91,4 +103,12 @@ jobs:
             echo "::warning::Latest stable version detected was ${{ steps.test_run.outputs.nsyte_version_used }}, expected v0.23.0. Check nsyte release tagging or the action's version resolution logic."
             # Not failing the test for this warning, but it's important to note.
           fi
+
+          if [[ "${{ steps.reject_sec1.outcome }}" != "failure" ]]; then
+            echo "::error::Expected the invalid nbunksec step to fail, but got '${{ steps.reject_sec1.outcome }}'."
+            exit 1
+          else
+            echo "Invalid nbunksec value was correctly rejected."
+          fi
+
           echo "Verification passed: Outputs are populated, and status is 'failure' as expected with dummy inputs." 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Deploy static websites to Blossom/Nostr in a GitHub Actions workflow, powered by
    ```bash
    nsyte ci
    ```
-   Follow the Nostr Connect prompts and `nsyte` will display a signing credential such as `nbunksec1...`; pass that value to this action via `sec`. It is revocable, but still treat it as a secret.
+   Follow the Nostr Connect prompts and `nsyte` will display a signing credential such as `nbunksec1...`; pass that value to this action via `nbunksec`. Do not paste a `sec1...` private key into this action.
 
 2. **Add GitHub Secret**:
    - Add the generated credential as a repository secret, for example `NBUNK_SECRET`
@@ -25,23 +25,22 @@ Deploy static websites to Blossom/Nostr in a GitHub Actions workflow, powered by
     - name: Deploy to Nostr/Blossom
       uses: sandwichfarm/nsite-action@v0.2.2
       with:
-        sec: ${{ secrets.NBUNK_SECRET }}
+        nbunksec: ${{ secrets.NBUNK_SECRET }}
         directory: './dist'  # Your built website directory
         version: 'v0.23.0'
         relays: |
           wss://relay.nsite.lol
         servers: |
-         https://cdn.hzrd149.com
-         https://cdn.sovbit.host
-   ```
+          https://cdn.hzrd149.com
+          https://cdn.sovbit.host
+    ```
 
 ## Inputs
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `version` | No | `latest` | nsyte release tag to download (for example `v0.23.0`) |
-| `sec` | No | - | Signing secret passed to nsyte via `--sec`; accepts `nsec`, `nbunksec`, `bunker://` URL, or hex |
-| `nbunksec` | No | - | Deprecated action-only compatibility alias for `sec` |
+| `nbunksec` | No | - | Recommended CI credential. Must start with `nbunksec1`. This action rejects `sec1` values for this input. |
 | `directory` | Yes | - | Directory containing website files |
 | `relays` | No | `''` | Newline-separated relay URIs |
 | `servers` | No | `''` | Newline-separated Blossom server URIs |
@@ -71,7 +70,7 @@ Deploy static websites to Blossom/Nostr in a GitHub Actions workflow, powered by
 - Downloads nsyte binary automatically
 - Supports Linux, macOS, and Windows
 - Masks sensitive secrets in logs
-- Uses nsyte's `--sec` auth flag and keeps `nbunksec` only as a deprecated action compatibility alias
+- Accepts the safer `nbunksec` action input and passes it through to nsyte
 
 ## Credential Revocation
 
@@ -79,10 +78,17 @@ Deploy static websites to Blossom/Nostr in a GitHub Actions workflow, powered by
 - If you leak your signing credential, rotate it immediately.
 - Rotate credentials periodically: revoke the old credential, establish a new connection, and update your GitHub secret.
 
+## No Warranty
+
+- This action is provided without warranty of any kind, express or implied.
+- If a signing credential or private key is exposed, any resulting loss, impersonation, or irreversible publish action is your responsibility.
+- Nostr events and published site data may be replicated by relays and other infrastructure; compromise and publication are not generally revocable.
+
 ## Security Notes
 
+- **DO NOT** paste a `sec1...` private key into this action
+- Use `nsyte ci` and store only the resulting `nbunksec1...` credential as a GitHub Secret
 - **DO NOT** commit signing credentials to source code
-- Store the credential as a GitHub Secret
 - Configure bunker with minimal permissions
 - Consider pinning to a specific `version`
 - Rotate credentials periodically

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Deploy static websites to Blossom/Nostr in a GitHub Actions workflow, powered by
    ```bash
    nsyte ci
    ```
-   Follow the Nostr Connect prompts and `nsyte` will display a signing credential such as `nbunksec`; it is revocable, but still treat it as a secret.
+   Follow the Nostr Connect prompts and `nsyte` will display a signing credential such as `nbunksec1...`; pass that value to this action via `sec`. It is revocable, but still treat it as a secret.
 
 2. **Add GitHub Secret**:
    - Add the generated credential as a repository secret, for example `NBUNK_SECRET`
@@ -40,13 +40,13 @@ Deploy static websites to Blossom/Nostr in a GitHub Actions workflow, powered by
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `version` | No | `latest` | nsyte release tag to download (for example `v0.23.0`) |
-| `sec` | No | - | Signing secret; accepts `nsec`, `nbunksec`, `bunker://` URL, or hex |
-| `nbunksec` | No | - | Deprecated alias for `sec` |
+| `sec` | No | - | Signing secret passed to nsyte via `--sec`; accepts `nsec`, `nbunksec`, `bunker://` URL, or hex |
+| `nbunksec` | No | - | Deprecated action-only compatibility alias for `sec` |
 | `directory` | Yes | - | Directory containing website files |
 | `relays` | No | `''` | Newline-separated relay URIs |
 | `servers` | No | `''` | Newline-separated Blossom server URIs |
 | `force` | No | false | Re-upload all files |
-| `purge` | No | false | Deprecated; no longer supported by `nsyte` |
+| `purge` | No | false | Deprecated; there is no deploy-time `--purge` flag in `nsyte` |
 | `sync` | No | false | Check all servers and upload missing blobs |
 | `verbose` | No | false | Show detailed output |
 | `concurrency` | No | 4 | Number of parallel uploads |
@@ -71,7 +71,7 @@ Deploy static websites to Blossom/Nostr in a GitHub Actions workflow, powered by
 - Downloads nsyte binary automatically
 - Supports Linux, macOS, and Windows
 - Masks sensitive secrets in logs
-- Accepts `sec` directly and keeps `nbunksec` as a deprecated alias
+- Uses nsyte's `--sec` auth flag and keeps `nbunksec` only as a deprecated action compatibility alias
 
 ## Credential Revocation
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 <!-- [![GitHub release (latest by date)](https://img.shields.io/github/v/release/your-username/nsite-action)](https://github.com/your-username/nsite-action/releases)
 [![GitHub Actions CI](https://github.com/your-username/nsite-action/actions/workflows/test.yml/badge.svg)](https://github.com/your-username/nsite-action/actions/workflows/test.yml) -->
 
-Deploy static websites to Blossom/Nostr in a Github Actions Workflow, powered by [nsyte](https://github.com/sandwichfarm/nsyte).
+Deploy static websites to Blossom/Nostr in a GitHub Actions workflow, powered by [nsyte](https://github.com/sandwichfarm/nsyte).
 
 ## Dependencies
 - Bunker Signer (NIP-46) for establishing a handshake
-- [nsyte](http://github.com/sandwichfarm/nsyte) - For generating an `nbunksec` bunker secret key.
+- [nsyte](https://github.com/sandwichfarm/nsyte) - For generating a signing credential with `nsyte ci`.
 
 ## Quick Start
 
@@ -15,21 +15,22 @@ Deploy static websites to Blossom/Nostr in a Github Actions Workflow, powered by
    ```bash
    nsyte ci
    ```
-   Follow prompts for Nostr Connect and it will display an **nbunksec**; this is a revocable credential, but still treat it as a secret.
+   Follow the Nostr Connect prompts and `nsyte` will display a signing credential such as `nbunksec`; it is revocable, but still treat it as a secret.
 
 2. **Add GitHub Secret**:
-   - Add the `nbunksec` string as a repository secret named `NBUNKSEC`
+   - Add the generated credential as a repository secret, for example `NBUNK_SECRET`
 
 3. **Add to workflow**:
-   ```yaml
-   - name: Deploy to Nostr/Blossom
-     uses: sandwichfarm/nsite-action@v0.2.2
-     with:
-       nbunksec: ${{ secrets.NBUNKSEC }}
-       directory: './dist'  # Your built website directory
-       relays: |
-         wss://relay.nsite.lol
-       servers: |
+    ```yaml
+    - name: Deploy to Nostr/Blossom
+      uses: sandwichfarm/nsite-action@v0.2.2
+      with:
+        sec: ${{ secrets.NBUNK_SECRET }}
+        directory: './dist'  # Your built website directory
+        version: 'v0.23.0'
+        relays: |
+          wss://relay.nsite.lol
+        servers: |
          https://cdn.hzrd149.com
          https://cdn.sovbit.host
    ```
@@ -38,19 +39,25 @@ Deploy static websites to Blossom/Nostr in a Github Actions Workflow, powered by
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `nbunksec` | Yes | - | Bunker auth string (store as GitHub Secret) |
+| `version` | No | `latest` | nsyte release tag to download (for example `v0.23.0`) |
+| `sec` | No | - | Signing secret; accepts `nsec`, `nbunksec`, `bunker://` URL, or hex |
+| `nbunksec` | No | - | Deprecated alias for `sec` |
 | `directory` | Yes | - | Directory containing website files |
-| `relays` | Yes | - | Newline separated relay URIs |
-| `servers` | Yes | - | Newline separated server URIs |
-| `nsyte_version` | No | latest | Version tag (e.g., "v0.5.0") |
+| `relays` | No | `''` | Newline-separated relay URIs |
+| `servers` | No | `''` | Newline-separated Blossom server URIs |
 | `force` | No | false | Re-upload all files |
-| `purge` | No | false | Delete remote files not present locally |
+| `purge` | No | false | Deprecated; no longer supported by `nsyte` |
+| `sync` | No | false | Check all servers and upload missing blobs |
 | `verbose` | No | false | Show detailed output |
 | `concurrency` | No | 4 | Number of parallel uploads |
 | `fallback` | No | '' | Fallback HTML path (e.g., "/index.html") |
-| `publish_server_list` | No | false | use this for new/fresh npubs without blossom servers configured |
-| `publish_relay_list` | No | false | use this for new/fresh npubs without relays configured |
-| `publish_profile` | No | false | use this for new/fresh npubs without a profile configured |
+| `publish_server_list` | No | false | Publish configured servers for fresh identities |
+| `publish_relay_list` | No | false | Publish configured relays for fresh identities |
+| `publish_profile` | No | false | Publish profile metadata for fresh identities |
+| `use_fallback_relays` | No | false | Include nsyte default relays in addition to configured relays |
+| `use_fallback_servers` | No | false | Include nsyte default servers in addition to configured servers |
+| `publish_app_handler` | No | false | Publish a NIP-89 app handler announcement |
+| `handler_kinds` | No | `''` | Comma-separated event kinds for the app handler |
 
 ## Outputs
 
@@ -64,21 +71,21 @@ Deploy static websites to Blossom/Nostr in a Github Actions Workflow, powered by
 - Downloads nsyte binary automatically
 - Supports Linux, macOS, and Windows
 - Masks sensitive secrets in logs
-- Authenticates via NIP-46 bunker
+- Accepts `sec` directly and keeps `nbunksec` as a deprecated alias
 
-## `nbunksec` Revocation
+## Credential Revocation
 
-- Revocation is handled by your Bunker Signer of choice (NIP-46).
-- If you leak your `nbunksec` you should rotate your keys.
-- keys should be rotated periodically (revoke old `nbunksec`, establish a new connection and update secrets)
+- Revocation is handled by your bunker signer of choice (NIP-46).
+- If you leak your signing credential, rotate it immediately.
+- Rotate credentials periodically: revoke the old credential, establish a new connection, and update your GitHub secret.
 
 ## Security Notes
 
-- **DO NOT** store `nbunksec` as an environment variable or commit to source code
-- Store `nbunksec` as a GitHub Secret
+- **DO NOT** commit signing credentials to source code
+- Store the credential as a GitHub Secret
 - Configure bunker with minimal permissions
-- Consider pinning to specific `nsyte_version`
-- Rotate `nbunksec` periodically
+- Consider pinning to a specific `version`
+- Rotate credentials periodically
 
 ## Resources
 - [awesome-nsite](https://github.com/nostrver-se/awesome-nsite)

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,10 @@ inputs:
     required: false
     default: 'latest'
   sec:
-    description: 'The signing secret for authentication. Accepts nsec, nbunksec, bunker:// URL, or hex. Store as a GitHub Secret.'
+    description: 'The signing secret for authentication, passed to nsyte via --sec. Accepts nsec, nbunksec, bunker:// URL, or hex. Store as a GitHub Secret.'
     required: false
   nbunksec:
-    description: 'DEPRECATED: Use "sec" instead. The nbunksec string for authentication via NIP-46 bunker. Store this as a GitHub Secret.'
+    description: 'DEPRECATED compatibility alias for "sec". nsyte no longer has a separate --nbunksec flag; pass nbunksec credentials via --sec instead.'
     required: false
   directory:
     description: 'The directory containing the static files to deploy.'
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: ''
   servers:
-    description: 'Newline-separated list of Blossom server URIs to deploy files to.'
+    description: 'Newline-separated list of Blossom server HTTPS URLs to deploy files to.'
     required: false
     default: ''
   force:
@@ -29,7 +29,7 @@ inputs:
     required: false
     default: 'false'
   purge:
-    description: 'DEPRECATED: No longer supported in nsyte. Use the nsyte "delete" or "undeploy" commands instead.'
+    description: 'DEPRECATED: There is no deploy-time purge flag in nsyte. Use the nsyte "delete" or "undeploy" commands instead.'
     required: false
     default: 'false'
   sync:
@@ -53,7 +53,7 @@ inputs:
     required: false
     default: 'false'
   publish_relay_list: 
-    description: 'true/false. If true, the relay list will be published to Blossom servers.'
+    description: 'true/false. If true, the relay list will be published to relays.'
     required: false
     default: 'false'
   publish_profile:
@@ -244,7 +244,7 @@ runs:
       shell: bash
       run: |
         # The -i flag is critical for non-interactive CI environments
-        # Use 'sec' input if provided, fall back to deprecated 'nbunksec'
+        # Use 'sec' input if provided, fall back to deprecated action-level 'nbunksec' alias
         SEC_VALUE="${{ inputs.sec || inputs.nbunksec }}"
         CMD="\"${{ steps.download_nsyte.outputs.nsyte_path }}\" deploy \"${{ inputs.directory }}\" -i --sec \"$SEC_VALUE\""
 

--- a/action.yml
+++ b/action.yml
@@ -311,4 +311,12 @@ runs:
            #echo "::set-output name=status::failure"
            echo "status=failure" >> $GITHUB_OUTPUT
         fi
-        exit "$COMMAND_EXIT_CODE"
+        echo "exit_code=$COMMAND_EXIT_CODE" >> $GITHUB_OUTPUT
+        exit 0
+
+    - name: Fail composite action on nsyte error
+      if: ${{ steps.nsyte_run.outputs.exit_code != '0' }}
+      shell: bash
+      run: |
+        echo "Failing action because nsyte exited with code ${{ steps.nsyte_run.outputs.exit_code }}."
+        exit 1

--- a/action.yml
+++ b/action.yml
@@ -299,7 +299,7 @@ runs:
         
         eval "$NSYT_COMMAND"
         COMMAND_EXIT_CODE=$? # Capture the exit code of the nsyte command
-        echo COMMAND_EXIT_CODE=$?
+        echo "COMMAND_EXIT_CODE=$COMMAND_EXIT_CODE"
 
         if [[ $COMMAND_EXIT_CODE -eq 0 ]]; then
            echo "nsyte deploy completed successfully."
@@ -310,7 +310,5 @@ runs:
            echo "::error::nsyte deploy command failed with exit code $COMMAND_EXIT_CODE." # Log the error
            #echo "::set-output name=status::failure"
            echo "status=failure" >> $GITHUB_OUTPUT
-           # This script step itself should still exit 0 to ensure outputs are processed.
-           # The calling workflow (test.yml) has continue-on-error: true and will check the 'status' output.
         fi
-        exit 0 # Explicitly exit 0 for this script step 
+        exit "$COMMAND_EXIT_CODE"

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,10 @@ inputs:
     required: false
     default: 'latest'
   sec:
-    description: 'The signing secret for authentication, passed to nsyte via --sec. Accepts nsec, nbunksec, bunker:// URL, or hex. Store as a GitHub Secret.'
+    description: 'Compatibility input. Prefer nbunksec; this value is still passed to nsyte via --sec.'
     required: false
   nbunksec:
-    description: 'DEPRECATED compatibility alias for "sec". nsyte no longer has a separate --nbunksec flag; pass nbunksec credentials via --sec instead.'
+    description: 'Recommended CI signing credential. Must start with nbunksec1; this action rejects sec1 values to discourage direct private key usage.'
     required: false
   directory:
     description: 'The directory containing the static files to deploy.'
@@ -244,7 +244,19 @@ runs:
       shell: bash
       run: |
         # The -i flag is critical for non-interactive CI environments
-        # Use 'sec' input if provided, fall back to deprecated action-level 'nbunksec' alias
+        NBUNKSEC_VALUE="${{ inputs.nbunksec }}"
+        if [[ -n "$NBUNKSEC_VALUE" ]]; then
+          if [[ "$NBUNKSEC_VALUE" == sec1* ]]; then
+            echo "::error::The 'nbunksec' input must not be a sec1 private key. Generate a CI credential with 'nsyte ci' and use the resulting nbunksec1 value instead."
+            exit 1
+          fi
+          if [[ "$NBUNKSEC_VALUE" != nbunksec1* ]]; then
+            echo "::error::The 'nbunksec' input must start with 'nbunksec1'."
+            exit 1
+          fi
+        fi
+
+        # Pass either compatibility input through nsyte's --sec flag
         SEC_VALUE="${{ inputs.sec || inputs.nbunksec }}"
         CMD="\"${{ steps.download_nsyte.outputs.nsyte_path }}\" deploy \"${{ inputs.directory }}\" -i --sec \"$SEC_VALUE\""
 

--- a/action.yml
+++ b/action.yml
@@ -95,13 +95,20 @@ runs:
       shell: bash
       run: |
         PLATFORM=""
+        ARCH_SUFFIX=""
         EXE_SUFFIX=""
         if [[ "${{ runner.os }}" == "Linux" ]]; then PLATFORM="linux";
-        elif [[ "${{ runner.os }}" == "macOS" ]]; then PLATFORM="macos";
+        elif [[ "${{ runner.os }}" == "macOS" ]]; then
+          PLATFORM="macos"
+          RUNNER_ARCH="$(uname -m)"
+          if [[ "$RUNNER_ARCH" == "arm64" ]]; then ARCH_SUFFIX="-arm64";
+          elif [[ "$RUNNER_ARCH" == "x86_64" ]]; then ARCH_SUFFIX="-x64";
+          else echo "::error::Unsupported macOS architecture: $RUNNER_ARCH"; exit 1; fi
         elif [[ "${{ runner.os }}" == "Windows" ]]; then PLATFORM="windows"; EXE_SUFFIX=".exe";
         else echo "::error::Unsupported runner OS: ${{ runner.os }}"; exit 1; fi
-        echo "Detected platform: $PLATFORM"
+        echo "Detected platform: $PLATFORM$ARCH_SUFFIX"
         echo "platform=$PLATFORM" >> $GITHUB_OUTPUT
+        echo "arch_suffix=$ARCH_SUFFIX" >> $GITHUB_OUTPUT
         echo "exe_suffix=$EXE_SUFFIX" >> $GITHUB_OUTPUT
 
     - name: Ensure jq is installed
@@ -186,16 +193,35 @@ runs:
         VERSION_TAG="${{ steps.version.outputs.version }}"
         VERSION_NUMBER="${{ steps.version.outputs.version_number }}"
         PLATFORM="${{ steps.platform.outputs.platform }}"
+        ARCH_SUFFIX="${{ steps.platform.outputs.arch_suffix }}"
         EXE_SUFFIX="${{ steps.platform.outputs.exe_suffix }}"
-        ASSET_FILENAME="nsyte-$PLATFORM-$VERSION_NUMBER$EXE_SUFFIX"
-        DOWNLOAD_URL="https://github.com/sandwichfarm/nsyte/releases/download/$VERSION_TAG/$ASSET_FILENAME"
-        echo "Downloading nsyte $ASSET_FILENAME from $DOWNLOAD_URL"
         mkdir -p nsyte_bin 
-        HTTP_STATUS=$(curl -sL -w "%{http_code}" -o "nsyte_bin/$ASSET_FILENAME" "$DOWNLOAD_URL")
-        if [[ "$HTTP_STATUS" != "200" ]]; then
-          echo "::error::Failed to download $ASSET_FILENAME (HTTP Status: $HTTP_STATUS)."
-          echo "Please check if version '$VERSION_TAG' and asset '$ASSET_FILENAME' exist for platform '$PLATFORM'."
-          
+
+        ASSET_CANDIDATES=()
+        if [[ "$PLATFORM" == "macos" ]]; then
+          ASSET_CANDIDATES+=("nsyte-$PLATFORM$ARCH_SUFFIX-$VERSION_NUMBER$EXE_SUFFIX")
+          ASSET_CANDIDATES+=("nsyte-$PLATFORM$ARCH_SUFFIX$EXE_SUFFIX")
+        else
+          ASSET_CANDIDATES+=("nsyte-$PLATFORM-$VERSION_NUMBER$EXE_SUFFIX")
+          ASSET_CANDIDATES+=("nsyte-$PLATFORM$EXE_SUFFIX")
+        fi
+
+        ASSET_FILENAME=""
+        for CANDIDATE in "${ASSET_CANDIDATES[@]}"; do
+          DOWNLOAD_URL="https://github.com/sandwichfarm/nsyte/releases/download/$VERSION_TAG/$CANDIDATE"
+          echo "Trying nsyte asset $CANDIDATE from $DOWNLOAD_URL"
+          HTTP_STATUS=$(curl -sL -w "%{http_code}" -o "nsyte_bin/$CANDIDATE" "$DOWNLOAD_URL")
+          if [[ "$HTTP_STATUS" == "200" ]]; then
+            ASSET_FILENAME="$CANDIDATE"
+            break
+          fi
+          rm -f "nsyte_bin/$CANDIDATE"
+        done
+
+        if [[ -z "$ASSET_FILENAME" ]]; then
+          echo "::error::Failed to download a compatible nsyte asset for version '$VERSION_TAG'."
+          echo "Tried assets: ${ASSET_CANDIDATES[*]}"
+
           if command -v gh &> /dev/null && gh auth status &> /dev/null; then
             gh release view "$VERSION_TAG" -R sandwichfarm/nsyte --json assets --jq '.assets[].name' 2>/dev/null || echo "(Could not list assets with gh CLI)"
           else 
@@ -203,6 +229,8 @@ runs:
           fi
           exit 1
         fi
+
+        echo "Downloaded nsyte asset: $ASSET_FILENAME"
         chmod +x "nsyte_bin/$ASSET_FILENAME"
         # Using ::set-output for nsyte_path
         #echo "::set-output name=nsyte_path::$(pwd)/nsyte_bin/$ASSET_FILENAME"

--- a/action.yml
+++ b/action.yml
@@ -250,7 +250,7 @@ runs:
 
         # Handle relays as newline-separated list
         if [[ -n "${{ inputs.relays }}" ]]; then
-          RELAYS_CSV=$(echo "${{ inputs.relays }}" | grep -v '^[[:space:]]*$' | paste -sd,)
+          RELAYS_CSV=$(printf '%s' "${{ inputs.relays }}" | grep -v '^[[:space:]]*$' | tr '\n' ',' | sed 's/,$//')
           if [[ -n "$RELAYS_CSV" ]]; then
              CMD+=" --relays \"$RELAYS_CSV\""
           fi
@@ -258,7 +258,7 @@ runs:
 
         # Handle servers as newline-separated list
         if [[ -n "${{ inputs.servers }}" ]]; then
-          SERVERS_CSV=$(echo "${{ inputs.servers }}" | grep -v '^[[:space:]]*$' | paste -sd,)
+          SERVERS_CSV=$(printf '%s' "${{ inputs.servers }}" | grep -v '^[[:space:]]*$' | tr '\n' ',' | sed 's/,$//')
           if [[ -n "$SERVERS_CSV" ]]; then
             CMD+=" --servers \"$SERVERS_CSV\""
           fi

--- a/action.yml
+++ b/action.yml
@@ -80,8 +80,10 @@ inputs:
 outputs:
   status:
     description: 'Status of the deploy operation (e.g., "success").'
+    value: ${{ steps.nsyte_run.outputs.status }}
   nsyte_version_used:
     description: 'The actual version of nsyte that was downloaded and used.'
+    value: ${{ steps.nsyte_run.outputs.nsyte_version_used }}
 
 branding:
   icon: 'upload-cloud'

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -56,16 +56,16 @@ echo "Created test-local-dir/index.html"
 
 # Define dummy relays and servers for example
 TEST_RELAYS="wss://relay.example.com,wss://nostr.example.org"
-TEST_SERVERS="wss://blossom.example.com"
+TEST_SERVERS="https://blossom.example.com"
 
 echo
 echo "Would construct command like:"
-echo "$FAKE_BINARY_NAME deploy './test-local-dir' --sec '<nsec|nbunksec|bunker://|hex>' --relays '$TEST_RELAYS' --servers '$TEST_SERVERS' [OTHER_FLAGS]"
+echo "$FAKE_BINARY_NAME deploy './test-local-dir' --sec '<nsec|nbunksec1|bunker://|hex>' --relays '$TEST_RELAYS' --servers '$TEST_SERVERS' [OTHER_FLAGS]"
 
 echo
 echo "=== Test Complete ==="
 echo "To run the actual action, you'd need to:"
 echo "1. Push this repo to GitHub"
-echo "2. Set up appropriate secrets (SEC - accepts nsec, nbunksec, bunker://, or hex)"
+echo "2. Set up appropriate secrets (SEC - passed to nsyte via --sec and accepts nsec, nbunksec, bunker://, or hex)"
 echo "3. Configure relays and servers in your workflow"
 echo "4. Run the workflow in Actions tab or use 'act' locally" 


### PR DESCRIPTION
## Summary
- update the test workflow to pass the action's `version` input instead of the stale `nsyte_version` name
- refresh the README examples and inputs table to document `version`, `sec`, and the deprecated `nbunksec` alias accurately
- align the latest-version warning text with current stable nsyte release behavior